### PR TITLE
[hotfix] Global Exception Handler Swagger Error

### DIFF
--- a/utils/exception-handler/build.gradle
+++ b/utils/exception-handler/build.gradle
@@ -5,6 +5,7 @@ project(":utils:exception-handler") {
     dependencies {
         implementation 'org.springframework:spring-web:6.1.8'
         implementation 'org.springframework.boot:spring-boot-starter-validation'
+        implementation 'org.springdoc:springdoc-openapi-common:1.8.0'
         implementation project(':utils:api-utils')
     }
 }

--- a/utils/exception-handler/src/main/java/com/pda/exceptionhandler/GlobalExceptionHandler.java
+++ b/utils/exception-handler/src/main/java/com/pda/exceptionhandler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.pda.apiutils.ApiUtils;
 import com.pda.apiutils.GlobalExceptionResponse;
 import com.pda.exceptionhandler.exceptions.BadRequestException;
 import com.pda.exceptionhandler.exceptions.ConflictException;
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -16,7 +17,7 @@ import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(BadRequestException.class)
+    @ExceptionHandler({BadRequestException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public GlobalExceptionResponse<String> handleBadRequestException(final BadRequestException e) {
         return ApiUtils.exception(e.getMessage());
@@ -30,6 +31,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Hidden
     public GlobalExceptionResponse<List<String>> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
         return ApiUtils.exceptions(e.getBindingResult()
             .getFieldErrors()


### PR DESCRIPTION
## 📄 Summary
- 글로벌 예외 처리기 문제되는 부분 Hidden
<br/>

## ✏️ Describe your changes
```java
@ExceptionHandler(MethodArgumentNotValidException.class)
    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @Hidden
    public GlobalExceptionResponse<List<String>> handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
        return ApiUtils.exceptions(e.getBindingResult()
            .getFieldErrors()
            .stream().map(DefaultMessageSourceResolvable::getDefaultMessage)
            .collect(Collectors.toList()));
    }
```
<br/>

## 📍 Issue number and link
-
<br>
